### PR TITLE
Add simple CSV-based REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# CSV REST API
+
+This repository contains a simple FastAPI application that exposes data from a CSV file over a REST API. Authentication is token-based via the `Authorization` header or `token` query parameter.
+
+## Setup
+
+All required Python packages are preinstalled in the Codex environment. To run the server manually, use:
+
+```bash
+uvicorn app:app --reload
+```
+
+## Example Usage
+
+Assuming the server is running on `http://localhost:8000` and using the token `secret-token`:
+
+- Retrieve all items:
+
+  ```bash
+  curl -H "Authorization: Bearer secret-token" http://localhost:8000/items
+  ```
+
+- Retrieve a single item:
+
+  ```bash
+  curl -H "Authorization: Bearer secret-token" http://localhost:8000/items/1
+  ```
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,42 @@
+import csv
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from typing import List
+from pydantic import BaseModel
+
+TOKEN = "secret-token"
+
+app = FastAPI(title="CSV REST API")
+
+class Item(BaseModel):
+    id: int
+    name: str
+    value: int
+
+# Load CSV data once at startup
+items: List[Item] = []
+with open("data.csv", newline="") as csvfile:
+    reader = csv.DictReader(csvfile)
+    for row in reader:
+        items.append(Item(id=int(row["id"]), name=row["name"], value=int(row["value"])))
+
+def verify_token(request: Request):
+    token = request.headers.get("Authorization")
+    if token and token.startswith("Bearer "):
+        token = token.split(" ", 1)[1]
+    else:
+        token = request.query_params.get("token")
+    if token != TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+@app.get("/items", response_model=List[Item])
+async def get_items(dep=Depends(verify_token)):
+    return items
+
+@app.get("/items/{item_id}", response_model=Item)
+async def get_item(item_id: int, dep=Depends(verify_token)):
+    for item in items:
+        if item.id == item_id:
+            return item
+    raise HTTPException(status_code=404, detail="Item not found")
+

--- a/data.csv
+++ b/data.csv
@@ -1,0 +1,4 @@
+id,name,value
+1,Item A,10
+2,Item B,20
+3,Item C,30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- add a sample FastAPI application reading `data.csv`
- implement token-based authentication
- provide example CSV data
- document usage in README
- specify Python requirements

## Testing
- `uvicorn app:app --port 8001 --reload` (manual)
- `curl -H "Authorization: Bearer secret-token" http://localhost:8001/items` (manual)


------
https://chatgpt.com/codex/tasks/task_e_6852e7763e5883299dfb74120c184a84