### PR TITLE
Add OpenAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ Assuming the server is running on `http://localhost:8000` and using the token `s
   curl -H "Authorization: Bearer secret-token" http://localhost:8000/items/1
   ```
 
+
+## OpenAPI Specification
+
+The `openapi.json` file in this repository contains the API description in the OpenAPI v3 format. It was generated from the FastAPI application and can be used to explore the endpoints or generate API clients.
+

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,143 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "CSV REST API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/items": {
+      "get": {
+        "summary": "Get Items",
+        "operationId": "get_items_items_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Items Items Get",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Item"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{item_id}": {
+      "get": {
+        "summary": "Get Item",
+        "operationId": "get_item_items__item_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "integer"
+            },
+            "name": "item_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Item"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "Item": {
+        "title": "Item",
+        "required": [
+          "id",
+          "name",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "integer"
+          }
+        }
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- generate `openapi.json` specification from the FastAPI app
- document the spec in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e87f0b388329b81356e39d506c49