### PR TITLE
Add pytest tests and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ This repository contains a simple FastAPI application that exposes data from a C
 
 ## Setup
 
-All required Python packages are preinstalled in the Codex environment. To run the server manually, use:
+Install the required packages (if not already available) with:
+
+```bash
+pip install -r requirements.txt
+```
+
+To run the server manually, use:
 
 ```bash
 uvicorn app:app --reload
@@ -31,3 +37,13 @@ Assuming the server is running on `http://localhost:8000` and using the token `s
 
 The `openapi.json` file in this repository contains the API description in the OpenAPI v3 format. It was generated from the FastAPI application and can be used to explore the endpoints or generate API clients.
 
+
+## Running Tests
+
+Tests are written with `pytest`. From the repository root run:
+
+```bash
+pytest
+```
+
+If `pytest` is not installed, you can add it via `pip install pytest`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 pydantic
+httpx
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi.testclient import TestClient
+from app import app
+
+client = TestClient(app)
+TOKEN = "secret-token"
+
+
+def test_get_items_success():
+    response = client.get("/items", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 3
+    assert data[0]["id"] == 1
+
+
+def test_get_item_success():
+    response = client.get("/items/2", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 2
+    assert data["name"] == "Item B"
+
+
+def test_get_item_not_found():
+    response = client.get("/items/999", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert response.status_code == 404
+
+
+def test_missing_token():
+    response = client.get("/items")
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- add pytest-based tests for API endpoints
- update documentation with setup and test instructions
- include testing dependencies in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6852e960425c83298c6897a16e056271